### PR TITLE
规范用法

### DIFF
--- a/moudleDemo/executePy/go.mod
+++ b/moudleDemo/executePy/go.mod
@@ -1,3 +1,5 @@
 module executePy
 
 go 1.15
+
+require golang.org/x/sync v0.0.0-20201207232520-09787c993a3a

--- a/moudleDemo/executePy/go.sum
+++ b/moudleDemo/executePy/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/moudleDemo/upload/go.mod
+++ b/moudleDemo/upload/go.mod
@@ -2,4 +2,4 @@ module upload
 
 go 1.15
 
-require github.com/gin-gonic/gin v1.6.3 // indirect
+require github.com/gin-gonic/gin v1.6.3

--- a/moudleDemo/upload/uploadDemo.go
+++ b/moudleDemo/upload/uploadDemo.go
@@ -14,6 +14,9 @@ func main() {
 	r.Run()
 }
 
+// FormFile调用了ParseMultipartForm，已经分配了32MB的内存，超出32MB的部分以临时文件保存起来了
+// 当SaveUploadedFile的时候，相当于打开临时文件，再写入自己的文件中，效率并不高
+// 建议直接使用MultipartReader，自行处理各个Part。ParseMultipartForm本质上也是用的MultipartReader
 func uploadHandler(c *gin.Context) {
 	header, err := c.FormFile(uploadFileKey)
 	if err != nil {


### PR DESCRIPTION
- 引入了errgroup，替换WaitGroup
- 指出Go签名规范，函数自身不能决定自己被如何使用，尽可能不要在签名里包含sync相关内容
- Command的规范用法
- strings包和bytes包功能完全相同，字节处理使用bytes，字符处理使用strings
- 评论了ParseMultipartForm和MultipartReader的相对优劣